### PR TITLE
add defaultState option to set a fallback alarm panel state

### DIFF
--- a/alarm/panel.html
+++ b/alarm/panel.html
@@ -2,7 +2,8 @@
     RED.nodes.registerType('AnamicoAlarmPanel',{
         category: 'config',
         defaults: {
-            name: { value: "", required: true }
+            name: { value: "", required: true },
+            defaultState: { value: 0, required: true }
         },
         label: function() {
             return this.name || "Panel";
@@ -15,7 +16,16 @@
         <label for="node-config-input-name"><i class="icon-bookmark"></i> Name</label>
         <input type="text" id="node-config-input-name">
     </div>
-    <div class="form-tips">Tip: don't forget to turn on persistence for global state, or when you restart node-red it will reset alarm state to "Home" every time.</div>
+    <div class="form-row">
+        <label for="node-config-input-defaultState"><i class="fa fa-cog"></i> Default state</label>
+        <select id="node-config-input-defaultState" name="node-config-input-defaultState">
+            <option value="0">Home</option>
+            <option value="1">Away</option>
+            <option value="2">Night</option>
+            <option value="3">Off</option>
+        </select>
+    </div>
+    <div class="form-tips">Tip: Don't forget to turn on persistence for global state. Otherwise the alarm state will be reset to the selected "Default state" when you restart Node-RED.</div>
 </script>
 
 <script type="text/x-red" data-help-name="AnamicoAlarmPanel">

--- a/alarm/panel.js
+++ b/alarm/panel.js
@@ -19,7 +19,15 @@ module.exports = function(RED) {
         console.log('node id ', node.nodeId);
         console.log('SecuritySystemCurrentState_' + node.nodeId);
 
-        this.alarmState = node.context().global.get('SecuritySystemCurrentState_' + node.nodeId) || 0;
+        this.defaultState = config.defaultState;
+
+        if(config.defaultState) {
+            this.defaultState = config.defaultState;
+        }else {
+            this.defaultState = 0;
+        }
+
+        this.alarmState = node.context().global.get('SecuritySystemCurrentState_' + node.nodeId) || this.defaultState;
         this.alarmType = node.context().global.get('SecuritySystemAlarmType_' + node.nodeId) || 0;
         this.isAlarm = node.alarmState === 4;
 
@@ -74,7 +82,7 @@ module.exports = function(RED) {
 
             // also emit current state on registration (after delay of 100 msec?):
             setTimeout(function() {
-                const alarmState = node.context().global.get('SecuritySystemCurrentState_' + node.nodeId) || 0;
+                const alarmState = node.context().global.get('SecuritySystemCurrentState_' + node.nodeId) || this.defaultState;
                 const alarmType = node.context().global.get('SecuritySystemAlarmType_' + node.nodeId) || 0;
                 const isAlarm = alarmState === 4;
                 // node.log(alarmState);


### PR DESCRIPTION
The alarm panel defaults to a hard-coded `0` state ("Home" mode), which immediately would result in an alarm after restarting Node-RED in case a "Home"-sensor triggers at this time.

I would like to avoid enabling the default use of persistent storage for global context variables. It would be sufficient for my environment to just start with a disabled alarm panel (state `3`) instead of "Home"-mode (state `0`).

To achieve this I extended the code to have a default/fallback state configurable instead of having it hard-coded to `0`. It would be used whenever Node-RED is started without an existing global `'SecuritySystemCurrentState_' + node.nodeId` variable.

This `defaultState` option as well defaults to `0`, so it shouldn't disturb existing setups.