### PR TITLE
add contextStore option to make the storage for global states selectable

### DIFF
--- a/alarm/panel.html
+++ b/alarm/panel.html
@@ -2,10 +2,19 @@
     RED.nodes.registerType('AnamicoAlarmPanel',{
         category: 'config',
         defaults: {
-            name: { value: "", required: true }
+            name: { value: "", required: true },
+            contextStore: {value: ""}
         },
         label: function() {
             return this.name || "Panel";
+        },
+        oneditprepare() {
+            const $nodeInputContextStore = $('#node-config-input-contextStore');
+
+            RED.settings.context.stores.forEach(store => {
+                $nodeInputContextStore.append('<option value="' + store + '"'
+                    + (this.contextStore === store ? ' selected' : '') + '>' + store + '</option>');
+            });
         }
     });
 </script>
@@ -15,7 +24,12 @@
         <label for="node-config-input-name"><i class="icon-bookmark"></i> Name</label>
         <input type="text" id="node-config-input-name">
     </div>
-    <div class="form-tips">Tip: don't forget to turn on persistence for global state, or when you restart node-red it will reset alarm state to "Home" every time.</div>
+    <div class="form-row">
+        <label for="node-input-contextStore"><i class="icon-tag"></i> Context Store</label>
+        <select id="node-config-input-contextStore">
+        </select>
+    </div>
+    <div class="form-tips">Tip: If you don't select a persistent context storage for the node's global state, Node-RED will reset alarm state to "Home" after a restart.</div>
 </script>
 
 <script type="text/x-red" data-help-name="AnamicoAlarmPanel">

--- a/alarm/panel.js
+++ b/alarm/panel.js
@@ -14,24 +14,26 @@ module.exports = function(RED) {
 
         // these nodes are in alarm state
         this.alarmNodes = new Set();
+        this.contextStore = config.contextStore;
 
         node.nodeId = node.id.replace(/\./g, '_');
         console.log('node id ', node.nodeId);
         console.log('SecuritySystemCurrentState_' + node.nodeId);
 
-        this.alarmState = node.context().global.get('SecuritySystemCurrentState_' + node.nodeId) || 0;
-        this.alarmType = node.context().global.get('SecuritySystemAlarmType_' + node.nodeId) || 0;
+        this.alarmState = node.context().global.get('SecuritySystemCurrentState_' + node.nodeId, node.contextStore) || 0;
+        this.alarmType = node.context().global.get('SecuritySystemAlarmType_' + node.nodeId, node.contextStore) || 0;
+
         this.isAlarm = node.alarmState === 4;
 
         this.setAlarmState = function(alarmState) {
             node.alarmState = alarmState;
             node.isAlarm = alarmState === 4;
-            node.context().global.set('SecuritySystemCurrentState_' + node.nodeId, alarmState);
+            node.context().global.set('SecuritySystemCurrentState_' + node.nodeId, alarmState, node.contextStore);
         };
 
         this.setAlarmType = function(alarmType) {
             this.alarmType = alarmType;
-            node.context().global.set('SecuritySystemAlarmType_' + node.nodeId, alarmType);
+            node.context().global.set('SecuritySystemAlarmType_' + node.nodeId, alarmType, node.contextStore);
         };
 
         /**
@@ -74,8 +76,8 @@ module.exports = function(RED) {
 
             // also emit current state on registration (after delay of 100 msec?):
             setTimeout(function() {
-                const alarmState = node.context().global.get('SecuritySystemCurrentState_' + node.nodeId) || 0;
-                const alarmType = node.context().global.get('SecuritySystemAlarmType_' + node.nodeId) || 0;
+                const alarmState = node.context().global.get('SecuritySystemCurrentState_' + node.nodeId, node.contextStore) || 0;
+                const alarmType = node.context().global.get('SecuritySystemAlarmType_' + node.nodeId, node.contextStore) || 0;
                 const isAlarm = alarmState === 4;
                 // node.log(alarmState);
                 // node.log(alarmType);


### PR DESCRIPTION
The alarm panel defaults to a hard-coded `0` state ("Home" mode), which immediately would result in an alarm after restarting Node-RED in case a "Home"-sensor triggers at this time. 

A workaround for this is documented in https://github.com/Anamico/node-red-contrib-alarm/issues/19#issuecomment-774623392 which consists of defaulting to file-based context storage in the whole Node-RED environment.

I would like to avoid enabling the default use of persistent storage for global context variables just because a single node depends on it, so I extended the alarm panel node. With this adjustment the storage to use becomes selectable. 

The new menu item uses the default Node-RED storage , but could be extended by using multiple context stores as documented here: https://nodered.org/docs/user-guide/context#using-multiple-context-stores

### Demo:

**settings.js**
```
contextStorage: {
    default: {
        module:"memory"
    },
    memory: { module: 'memory' },
    file: { module: 'localfilesystem' }
},
```

**Admin GUI**
AnamicoAlarmPanel:

![image](https://user-images.githubusercontent.com/7422872/124651459-3d058080-de9b-11eb-8823-62eb54671d5a.png)
