### PR TITLE
filtrex expressions

### DIFF
--- a/alarm/sensor.html
+++ b/alarm/sensor.html
@@ -6,7 +6,13 @@
             name: { value : "", required: true },
             panel: { type: 'AnamicoAlarmPanel', required: true },
             alarmStates: { value : "1", required: true, validate:RED.validators.regex(/.{1,}/) },
-            triggerType: { value : null, required: false }
+            triggerType: { value : null, required: false }, // Legacy property
+            triggerCondition: { value : "", required: false, validate:function(v) { return !this.triggerConditionError; } },
+            // Use the triggerConditionError property to let Node-RED know whether the trigger expression contains a syntax error or not.
+            // This way the flow editor knows whether a red triangle should be drawn for this node or not.
+            // The triggerConditionError property will be filled in the oneditsave.
+            // This way we can avoid running the expression check every time the validator is called, since the expression won't change meanwhile anyway...
+            triggerConditionError: { value : false},
         },
         inputs: 1,
         outputs: 0,
@@ -18,8 +24,47 @@
         paletteLabel: 'Alarm Sensor',
         oneditprepare: function() {
             //called at launch time
+            
+            var node = this;
 
+            // Check the expression syntax (at server side), for every change made in the expression input
+            $('#node-input-triggerCondition').keyup(function() {
+                var triggerExpression = this.value;
 
+                $.ajax({
+                    method: 'POST',
+                    url: 'anamico-alarm-sensor/check/',
+                    data: {expression: btoa(triggerExpression)},
+                    success: function(response){
+                        // Draw a red border around the expression input field if necessary (similar how the validation functions do it)
+                        if (response.result === "error") {
+                            $('#node-input-triggerCondition').addClass("input-error");
+                            node.triggerConditionError = true;
+                        }
+                        else { // "ok"
+                            $('#node-input-triggerCondition').removeClass("input-error");
+                            node.triggerConditionError = false;
+                        }
+                    }
+                });
+            });
+
+            // For older nodes (version 1.2.5 and below) there was a dropdown triggerType, but no triggerCondition expression.
+            // When the config screen of this node is being opened, the triggerType should be migrated to a corresponding triggerCondition expression.
+            if (!this.triggerCondition) {
+                if (this.triggerType == "1") {
+                    $('#node-input-triggerCondition').val("msg.payload.open == true");
+                }
+                else {
+                    // "Any message" means no trigger condition
+                    $('#node-input-triggerCondition').val("");
+                }
+            }
+            else {
+                // Make sure the condition is checked when the config screen is opened
+                $('#node-input-triggerCondition').val(this.triggerCondition);
+                $('#node-input-triggerCondition').keyup();
+            }
 
             $.get('allow2/paired/' + configId, function( data, textStatus, jqXHR ) {
                 //write access token value back out to the form
@@ -145,6 +190,13 @@
                 });
             });
         },
+        oneditsave: function() {
+            // Store the result of the last (server side) trigger expression check
+            this.triggerConditionError = false;
+            if ($('#node-input-triggerCondition').hasClass("input-error")) {
+               this.triggerConditionError = true;
+            }
+        },
         exportable: false
     });
 </script>
@@ -172,13 +224,10 @@
 
     <div class="form-row"></div>
     <div class="form-row">
-        <label for="node-input-triggerType"><i class="fa fa-filter"></i> Trigger</label>
-        <select id="node-input-triggerType">
-            <option value="">Any Message</option>
-            <option value="1">msg.payload.open == true</option>
-        </select>
+        <label for="node-input-triggerCondition"><i class="fa fa-filter"></i> Trigger</label>
+        <input type="text" id="node-input-triggerCondition" placeholder="Logical (boolean) expression">
     </div>
-    <div class="form-tips">Tip: Having no triggers defined will make this sensor trigger on ANY message. Otherwise, define a condition under which the sensor is considered "tripped".</div>
+    <div class="form-tips">Tip: Having no trigger condition defined will make this sensor trigger on ANY message. Otherwise, define a condition under which the sensor is considered "tripped".</div>
 </script>
 
 <script type="text/x-red" data-help-name="AnamicoAlarmSensor">

--- a/alarm/sensor.js
+++ b/alarm/sensor.js
@@ -64,10 +64,16 @@ module.exports = function(RED) {
             //node.log(node.alarmStates);
             
             if (!node.triggerFunction) {
+                node.warn("Invalid trigger condition expression cannot evaluate message");
                 return;
             }
             
             var trigger = node.triggerFunction({msg: msg});
+            
+            if (trigger !== true && trigger !== false) {
+                // Invalid input (e.g. "5" instead of 5) will result in trigger containing "TypeError: expected ..."
+                trigger = false;
+            }
 
             node.status({ fill:"blue", shape:"dot", text:"trigger" });
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   ],
   "dependencies": {
     "debug": "^4.3.1",
-    "async": "^2.6.1"
+    "async": "^2.6.1",
+    "filtrex": "^3.0.0-rc11"
   },
   "description": "Nodes to build your own home alarm system. Designed to work easily with (but does not require) homekit.",
   "devDependencies": {},


### PR DESCRIPTION
Dear,

As discussed in this [issue](https://github.com/Anamico/node-red-contrib-alarm/issues/25) I have integrated [filtrex](https://github.com/m93a/filtrex/) expressions into the Sensor node config screen.  

Note that I have included version filtrex version ***3.0.0-rc11*** as a dependency.  That is a release candidate version, but the author has planned the final 3.0.0 version in the near future.  I needed that version because the author has been so kind to implement boolean values and nested expressions for us.  So you can now use for example *"msg.payload == true"*, similar to the current dropdown value in this node...

Note that this pull request determines (based on the input message) whether the expression is true or false, but that value is **NOT** used to filter messages for alarms.  Reason why I haven't implemented that in this pull request, is that it is also not implemented yet (see [here](https://github.com/Anamico/node-red-contrib-alarm/issues/25#issuecomment-905399417)).  Moreover I don't know if/how you want to implement my [other](https://github.com/Anamico/node-red-contrib-alarm/issues/27) feature request.  Because when that would be implemented, the message always has to be processed (but the filtrex expression result value would only be used to determine whether an alarm should be triggered or not).  So I propose to keep that for a separate discussion...

This pull request also offers an extra server-side endpoint, which can be called by the frontend (config screen in flow editor) to do some (basic) real-time syntax checking:

![filtrex_checking](https://user-images.githubusercontent.com/14224149/135540161-28655adb-af59-4f05-b0d3-b551609d7050.gif)

I have tried to make sure that existing nodes are not impacted, by automatically converting the old dropdown values to corresponding filtrex expressions in the following situation:
+ on the client side, which is triggered when the config screens opens after the user has double clicked the node.
+ on the server-side, which is used in case an input message is injected but the user hasn't opened the node's config screen.

If you would like to test this backwards compatibility, the easiest way to do it is by adding a bunch of sensor nodes on the flow (when still using the old version).  Then install the new version, and test the old nodes in the above described two scenarios....

Hopefully you like it, because it was quite some work to implement it.
Thanks for reviewing !!
Bart