### PR TITLE
check the trigger function result before tripping the sensor

### DIFF
--- a/alarm/sensor.js
+++ b/alarm/sensor.js
@@ -75,6 +75,11 @@ module.exports = function(RED) {
                 trigger = false;
             }
 
+            // if the sensor wasn't triggered then exit early
+            if (!trigger) {
+                return;
+            }
+
             node.status({ fill:"blue", shape:"dot", text:"trigger" });
 
             msg.payload = {


### PR DESCRIPTION
previously the trigger function was being executed, but the result never checked - so any message was tripping the sensor